### PR TITLE
Preserve begin timestamp (key) in Agenda methods

### DIFF
--- a/src/provider/ical/calendar.rs
+++ b/src/provider/ical/calendar.rs
@@ -823,7 +823,7 @@ impl Calendarlike for Calendar {
     fn filter_events<'a>(
         &'a self,
         filter: EventFilter,
-    ) -> Box<dyn Iterator<Item = &(dyn Eventlike + 'a)> + 'a> {
+    ) -> Box<dyn Iterator<Item = (&DateTime<Tz>, &(dyn Eventlike + 'a))> + 'a> {
         // TODO: Change once https://github.com/rust-lang/rust/issues/86026 is stable
         let real_begin = match filter.begin {
             Bound::Included(dt) => {
@@ -847,8 +847,7 @@ impl Calendarlike for Calendar {
         Box::new(
             self.events
                 .range((real_begin, real_end))
-                .flat_map(|(_, v)| v.iter())
-                .map(|ev| (ev.as_ref() as &dyn Eventlike)),
+                .flat_map(|(e, v)| v.iter().map(move |ev| (e, ev.as_ref() as &dyn Eventlike))),
         )
     }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -305,7 +305,7 @@ pub trait Calendarlike {
     fn filter_events<'a>(
         &'a self,
         filter: EventFilter,
-    ) -> Box<dyn Iterator<Item = &(dyn Eventlike + 'a)> + 'a>;
+    ) -> Box<dyn Iterator<Item = (&DateTime<Tz>, &(dyn Eventlike + 'a))> + 'a>;
     fn new_event(&mut self);
 }
 


### PR DESCRIPTION
This timestamp is then also used in the EventWindow for sorting, thus fixing an incorrect ordering bug related to recurring events.

Also included is a minor refactoring in Agenda to deduplicate code between methods.