### PR TITLE
Implement jk-notify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "jackal"
 version = "0.1.0"
 authors = ["reedts <j.reedts@gmail.com>"]
 edition = "2018"
+default-run = "jk"
 
 [dependencies]
 chrono = "0.4.*"
@@ -27,4 +28,6 @@ rusty-hook = "0.11.2"
 
 [[bin]]
 name = "jk"
-path = "src/main.rs"
+
+[[bin]]
+name = "jk-notify"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ dirs = "4.0.0"
 uuid = { version = "1.0.0", features = ["v4"] }
 rrule = "0.10.0"
 notify-rust = "4.5"
+linkify = "0.9"
 
 [dev-dependencies]
 rusty-hook = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ nom = "7.1.0"
 dirs = "4.0.0"
 uuid = { version = "1.0.0", features = ["v4"] }
 rrule = "0.10.0"
+notify-rust = "4.5"
 
 [dev-dependencies]
 rusty-hook = "0.11.2"

--- a/src/bin/jk-notify.rs
+++ b/src/bin/jk-notify.rs
@@ -1,7 +1,8 @@
 extern crate jackal as lib;
 
+use chrono::{Duration, Utc};
 use flexi_logger::{Duplicate, FileSpec, Logger};
-use lib::events::Dispatcher;
+use lib::{agenda::Agenda, events::Dispatcher};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -9,7 +10,7 @@ use structopt::StructOpt;
 #[structopt(
     name = "jk-notify",
     author = "Julian Bigge <j.reedts@gmail.com>",
-    about = "Notification deamon of jackal."
+    about = "Notification deamon of the jackal calendar suite."
 )]
 pub struct Args {
     #[structopt(
@@ -41,5 +42,67 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = lib::config::load_suitable_config(args.configfile.as_deref())?;
 
     let _dispatcher = Dispatcher::from_config(&config);
-    Ok(())
+
+    let calendar = Agenda::from_config(&config)?;
+
+    let headsup_time = Duration::minutes(config.notification_headsup_minutes.into());
+    let check_window = Duration::days(1);
+    assert!(
+        check_window > headsup_time,
+        "Check window is too small for headsup time"
+    );
+    loop {
+        let begin = Utc::now().naive_utc();
+        let end = begin + check_window;
+
+        let mut next_events = calendar.events_in(begin..end).collect::<Vec<_>>();
+        next_events.sort_unstable_by_key(|(begin, _)| *begin);
+
+        for (begin, event) in next_events {
+            let begin_utc = begin.naive_utc();
+            let headsup_begin = begin_utc - headsup_time;
+            let now = Utc::now().naive_utc();
+            let to_sleep = headsup_begin - now;
+            log::info!(
+                "Sleeping {} until headsup time of next event {}",
+                to_sleep,
+                event.summary()
+            );
+
+            // Chrono duration may be negative, in which case we do not want to sleep
+            std::thread::sleep(to_sleep.to_std().unwrap_or(std::time::Duration::ZERO));
+
+            let end = *begin + event.duration();
+            let summary = format!("Upcoming event '{}'", event.title());
+            let with_dates = begin.date() != end.date();
+            let time_str = if with_dates {
+                format!("{}-{}", begin.naive_local(), end.naive_local())
+            } else {
+                format!(
+                    "{}-{}",
+                    begin.naive_local().time(),
+                    end.naive_local().time()
+                )
+            };
+            let body = format!("{}\n{}", time_str, event.summary());
+
+            let now = Utc::now().naive_utc();
+            let timeout = end.naive_utc() - now;
+            notify_rust::Notification::new()
+                .summary(&summary)
+                .body(&body)
+                .timeout(notify_rust::Timeout::Milliseconds(
+                    timeout.num_milliseconds() as u32,
+                ))
+                .show()
+                .unwrap();
+            log::info!("After notification");
+        }
+
+        let now = Utc::now().naive_utc();
+        let end = end - headsup_time;
+        let to_sleep = end - now;
+        eprintln!("No more events in batch. Sleeping for {}", to_sleep);
+        std::thread::sleep(to_sleep.to_std().unwrap_or(std::time::Duration::ZERO));
+    }
 }

--- a/src/bin/jk-notify.rs
+++ b/src/bin/jk-notify.rs
@@ -1,0 +1,45 @@
+extern crate jackal as lib;
+
+use flexi_logger::{Duplicate, FileSpec, Logger};
+use lib::events::Dispatcher;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "jk-notify",
+    author = "Julian Bigge <j.reedts@gmail.com>",
+    about = "Notification deamon of jackal."
+)]
+pub struct Args {
+    #[structopt(
+        name = "CONFIG",
+        short = "c",
+        long = "config",
+        help = "path to config file",
+        parse(from_os_str)
+    )]
+    pub configfile: Option<PathBuf>,
+
+    #[structopt(long = "log-file", help = "path to log file", parse(from_os_str))]
+    pub log_file: Option<PathBuf>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::from_args();
+
+    let mut logger = Logger::try_with_env_or_str("info")?.duplicate_to_stderr(Duplicate::Warn);
+
+    if let Some(log_file) = args.log_file {
+        logger = logger
+            .log_to_file(FileSpec::try_from(log_file)?)
+            .print_message();
+    }
+
+    logger.start()?;
+
+    let config = lib::config::load_suitable_config(args.configfile.as_deref())?;
+
+    let _dispatcher = Dispatcher::from_config(&config);
+    Ok(())
+}

--- a/src/bin/jk.rs
+++ b/src/bin/jk.rs
@@ -1,17 +1,12 @@
-mod agenda;
-mod config;
-mod events;
-mod provider;
-mod ui;
+extern crate jackal as lib;
 
-use agenda::Agenda;
-use config::Config;
-use events::Dispatcher;
 use flexi_logger::{Duplicate, FileSpec, Logger};
+use lib::agenda::Agenda;
+use lib::events::Dispatcher;
+use lib::ui::app::App;
 use std::io::stdout;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use ui::app::App;
 use unsegen::base::Terminal;
 
 #[derive(Debug, StructOpt)]
@@ -54,13 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     logger.start()?;
 
-    let config = if let Some(path) = args.configfile {
-        Config::load(&path)?
-    } else if let Ok(path) = config::find_configfile() {
-        Config::load(&path)?
-    } else {
-        Config::default()
-    };
+    let config = lib::config::load_suitable_config(args.configfile.as_deref())?;
 
     let dispatcher = Dispatcher::from_config(&config);
     // Setup unsegen terminal

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use toml;
 
 const DEFAULT_RECURRENCE_LOOKAHEAD: u32 = 356;
+const DEFAULT_NOTIFICATION_HEADSUP_MINUTES: u32 = 10;
 const CONFIG_PATH_ENV_VAR: &str = "JACKAL_CONFIG_FILE";
 
 fn find_configfile() -> io::Result<PathBuf> {
@@ -54,6 +55,10 @@ fn default_recurrence_lookahead() -> u32 {
     DEFAULT_RECURRENCE_LOOKAHEAD
 }
 
+fn default_notification_headsup_minutes() -> u32 {
+    DEFAULT_NOTIFICATION_HEADSUP_MINUTES
+}
+
 pub fn load_suitable_config(
     configfile: Option<&Path>,
 ) -> Result<Config, Box<dyn std::error::Error>> {
@@ -76,6 +81,10 @@ pub struct Config {
     // TODO: Implement as chrono::Duration with serde
     #[serde(default = "default_recurrence_lookahead")]
     pub recurrence_lookahead: u32,
+
+    #[serde(default = "default_notification_headsup_minutes")]
+    pub notification_headsup_minutes: u32,
+
     pub collections: Vec<CollectionSpec>,
 }
 
@@ -88,7 +97,8 @@ impl Default for Config {
                 PathBuf::from("jackal.toml")
             },
             tick_rate: Duration::from_secs(60),
-            recurrence_lookahead: 356,
+            recurrence_lookahead: default_recurrence_lookahead(),
+            notification_headsup_minutes: default_notification_headsup_minutes(),
             collections: Vec::new(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use toml;
 const DEFAULT_RECURRENCE_LOOKAHEAD: u32 = 356;
 const CONFIG_PATH_ENV_VAR: &str = "JACKAL_CONFIG_FILE";
 
-pub(crate) fn find_configfile() -> io::Result<PathBuf> {
+fn find_configfile() -> io::Result<PathBuf> {
     if let Ok(path) = env::var(CONFIG_PATH_ENV_VAR) {
         return Ok(PathBuf::from(path));
     }
@@ -52,6 +52,18 @@ fn default_tick_rate() -> Duration {
 
 fn default_recurrence_lookahead() -> u32 {
     DEFAULT_RECURRENCE_LOOKAHEAD
+}
+
+pub fn load_suitable_config(
+    configfile: Option<&Path>,
+) -> Result<Config, Box<dyn std::error::Error>> {
+    Ok(if let Some(path) = configfile {
+        Config::load(&path)?
+    } else if let Ok(path) = find_configfile() {
+        Config::load(&path)?
+    } else {
+        Config::default()
+    })
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod agenda;
+pub mod config;
+pub mod events;
+pub mod provider;
+pub mod ui;

--- a/src/provider/ical/calendar.rs
+++ b/src/provider/ical/calendar.rs
@@ -648,6 +648,10 @@ impl Eventlike for Event {
         self.title()
     }
 
+    fn description(&self) -> Option<&str> {
+        self.get_property_value("DESCRIPTION")
+    }
+
     fn set_summary(&mut self, summary: &str) {
         self.set_title(summary);
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -286,6 +286,7 @@ pub trait Eventlike {
     fn set_title(&mut self, title: &str);
     fn uuid(&self) -> Uuid;
     fn summary(&self) -> &str;
+    fn description(&self) -> Option<&str>;
     fn set_summary(&mut self, summary: &str);
     fn occurrence(&self) -> &Occurrence<Tz>;
     fn set_occurrence(&mut self, occurrence: Occurrence<Tz>);


### PR DESCRIPTION
This is a notification daemon that spawns notifications on upcoming events. Since support for alarm is not yet implemented, the "headsup" duration is currently specified globally in the config file.

Since this is the second binary of the project, the `main.rs` was also moved to a separate file `bin/jk.rs` which, however, is still the default binary.